### PR TITLE
Update BUILD.bazel to #keep npm_package(srcs)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,6 +5,10 @@ npm_link_all_packages(name = "node_modules")
 
 npm_package(
     name = "pkg",
-    srcs = ["package.json", "index.js", "index.html"],
+    srcs = [
+        "package.json",
+        "index.js", # keep
+        "index.html", # keep
+    ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
So running `configure` after adding this template doesn't remove these.